### PR TITLE
Update instructions for Fn key reversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ The Apple Magic Keyboard will require you to install the `.inf` files in both th
 
 ## Settings
 ### Function Key Reversal
-To reverse the function of the `Fn` key, change the following `DWORD (32-bit) Value`s in the Registry Editor from `0` to `1`:
+To reverse the function of the `Fn` key, change the following `REG_BINARY` values in the Registry Editor from `01` to `00`:
 
 `HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\KeyMagic\OSXFnBehavior`
+`HKEY_LOCAL_MACHINE\SYSTEM\ControlSet001\Services\KeyMagic2\OSXFnBehavior`
 `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\KeyMagic\OSXFnBehavior`
+`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\KeyMagic2\OSXFnBehavior`
+
+Then restart your computer
 
 ### Inverted Scrolling
 To reverse the direction of the scroll wheel the same way macOS does, change the following `DWORD (32-bit) Value` in the Registry Editor from `0` to `1` and restart your PC:


### PR DESCRIPTION
Updated them with what worked IME. The default values were 01 and pressing F1 required pressing both Fn and F1

Screenshot attached with the reversal applied.
![image](https://github.com/AbsentForeskin/Apple-Input-Device-Drivers-Windows-10-11/assets/20897849/cbf1b112-a761-4ba1-afd5-dcfe35b2a6d4)

I also required a restart for it to take effect. I try turning the keyboard on and off again to no effect. I'm using it over Bluetooth